### PR TITLE
#102 Fix doc is null bug in createOrUpdateUser.

### DIFF
--- a/app/controllers/userController.js
+++ b/app/controllers/userController.js
@@ -3,7 +3,6 @@
 
 var Q = require('q');
 var UserModel = require('../models/userModel');
-var winston = require('winston');
 
 
 exports.createOrUpdate = function(req, res, next) {
@@ -23,7 +22,7 @@ exports.createOrUpdate = function(req, res, next) {
         };
 
         var createOrUpdateUser = function() {
-            return Q.npost(UserModel, 'findOneAndUpdate', [query, update, {upsert: true}]);
+            return Q.npost(UserModel, 'findOneAndUpdate', [query, update, {new: true, upsert: true}]);
         };
 
         createOrUpdateUser()
@@ -33,11 +32,6 @@ exports.createOrUpdate = function(req, res, next) {
             })
             .done(function(doc) {
                 // TODO(allard): should this go somewhere else? It would be better to call the user ID from session.
-                // This log is temporary to figure out the bug where doc is null
-                if (!doc) {
-                    winston.error('doc is apparently null...');
-                    winston.error(doc, req, res, query, update);
-                }
                 res.locals.bwUser = req.bwUser = doc._doc;
                 return next();
             });


### PR DESCRIPTION
Add `new: true` to the options object to make the upsert command return the new object instead of the old one as per new documentation of Mongoose.

http://mongoosejs.com/docs/api.html#query_Query-findOneAndUpdate